### PR TITLE
dropdown calendar생성

### DIFF
--- a/src/components/common/Calendar/index.tsx
+++ b/src/components/common/Calendar/index.tsx
@@ -1,33 +1,36 @@
 import React from 'react';
 
-import { format } from 'date-fns';
-
 import { Button } from '@/components/ui/button';
 import { UiCalendar } from '@/components/ui/calendar';
 
+import useFormattedDate from '@/hooks/useFormatedDate';
+
 interface CalendarProps {
   isDropdown?: boolean;
+  handleCalendarClick?: (date: string) => void;
 }
 
-export default function Calendar({ isDropdown }: CalendarProps) {
+export default function Calendar({ isDropdown, handleCalendarClick }: CalendarProps) {
   const [date, setDate] = React.useState<Date | undefined>();
+
+  const { monthDayWithDayOfWeek } = useFormattedDate(date);
 
   const handleDateSelect = (selectedDate: Date | undefined) => {
     setDate(selectedDate);
   };
 
-  const formatDate = (date: Date | undefined) => {
-    return date ? format(date, 'yyyy년 MM월 dd일') : '날짜를 선택해주세요';
-  };
-
   return (
     <>
-      {isDropdown ? (
+      {isDropdown && handleCalendarClick ? (
         <div className="absolute rounded-md border bg-white p-12">
           <UiCalendar mode="single" selected={date} onSelect={handleDateSelect} />
           {isDropdown && (
-            <Button variant="secondary" className="mt-2 w-full">
-              {formatDate(date)}
+            <Button
+              variant="secondary"
+              className="mt-2 w-full"
+              onClick={() => handleCalendarClick(monthDayWithDayOfWeek)}
+            >
+              {monthDayWithDayOfWeek}
             </Button>
           )}
         </div>

--- a/src/components/common/Calendar/index.tsx
+++ b/src/components/common/Calendar/index.tsx
@@ -1,12 +1,46 @@
 import React from 'react';
 
+import { format } from 'date-fns';
+
+import { Button } from '@/components/ui/button';
 import { UiCalendar } from '@/components/ui/calendar';
 
-export default function Calendar() {
-  const [date, setDate] = React.useState<Date | undefined>(new Date());
-  console.log(date);
+interface CalendarProps {
+  isDropdown?: boolean;
+}
+
+export default function Calendar({ isDropdown }: CalendarProps) {
+  const [date, setDate] = React.useState<Date | undefined>();
+
+  const handleDateSelect = (selectedDate: Date | undefined) => {
+    setDate(selectedDate);
+  };
+
+  const formatDate = (date: Date | undefined) => {
+    return date ? format(date, 'yyyy년 MM월 dd일') : '날짜를 선택해주세요';
+  };
 
   return (
-    <UiCalendar mode="single" selected={date} onSelect={setDate} className="rounded-md border" />
+    <>
+      {isDropdown ? (
+        <div className="absolute rounded-md border bg-white p-12">
+          <UiCalendar mode="single" selected={date} onSelect={handleDateSelect} />
+          {isDropdown && (
+            <Button variant="secondary" className="mt-2 w-full">
+              {formatDate(date)}
+            </Button>
+          )}
+        </div>
+      ) : (
+        <>
+          <UiCalendar
+            mode="single"
+            selected={date}
+            onSelect={handleDateSelect}
+            className="rounded-me border"
+          />
+        </>
+      )}
+    </>
   );
 }

--- a/src/components/common/Calendar/index.tsx
+++ b/src/components/common/Calendar/index.tsx
@@ -4,6 +4,7 @@ import { UiCalendar } from '@/components/ui/calendar';
 
 export default function Calendar() {
   const [date, setDate] = React.useState<Date | undefined>(new Date());
+  console.log(date);
 
   return (
     <UiCalendar mode="single" selected={date} onSelect={setDate} className="rounded-md border" />

--- a/src/components/common/Dropdown/index.tsx
+++ b/src/components/common/Dropdown/index.tsx
@@ -40,6 +40,11 @@ export default function Dropdown({
     setItemValue(itemText);
   };
 
+  const handleCalendarClick = (date: string) => {
+    setIsOpen(false);
+    setItemValue(date);
+  };
+
   useEffect(() => {
     document.addEventListener('mousedown', handleClickOutside);
     return () => {
@@ -75,7 +80,7 @@ export default function Dropdown({
             ))}
           </div>
         ) : (
-          <Calendar isDropdown />
+          <Calendar isDropdown handleCalendarClick={handleCalendarClick} />
         )
       ) : null}
       {/* isOpen이 false일 때는 아무것도 렌더링하지 않음 */}

--- a/src/components/common/Dropdown/index.tsx
+++ b/src/components/common/Dropdown/index.tsx
@@ -2,6 +2,10 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import Image from 'next/image';
 
+import Calendar from '@/components/common/Calendar';
+
+import { Button } from '@/components/ui/button';
+
 interface DropdownProps {
   items?: string[];
   icon: string;
@@ -73,7 +77,12 @@ export default function Dropdown({
             ))}
           </div>
         ) : (
-          <div className="absolute z-10">Loading...</div> // items가 없는 경우
+          // <div className="absolute z-10">Loading...</div> // items가 없는 경우
+          <>
+            {/* button따로 없고  */}
+            <Calendar />
+            <Button>7월 25일 선택하기</Button>
+          </>
         )
       ) : null}
       {/* isOpen이 false일 때는 아무것도 렌더링하지 않음 */}

--- a/src/components/common/Dropdown/index.tsx
+++ b/src/components/common/Dropdown/index.tsx
@@ -4,8 +4,6 @@ import Image from 'next/image';
 
 import Calendar from '@/components/common/Calendar';
 
-import { Button } from '@/components/ui/button';
-
 interface DropdownProps {
   items?: string[];
   icon: string;
@@ -77,12 +75,7 @@ export default function Dropdown({
             ))}
           </div>
         ) : (
-          // <div className="absolute z-10">Loading...</div> // items가 없는 경우
-          <>
-            {/* button따로 없고  */}
-            <Calendar />
-            <Button>7월 25일 선택하기</Button>
-          </>
+          <Calendar isDropdown />
         )
       ) : null}
       {/* isOpen이 false일 때는 아무것도 렌더링하지 않음 */}

--- a/src/hooks/useFormatedDate.ts
+++ b/src/hooks/useFormatedDate.ts
@@ -1,0 +1,26 @@
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+
+const useFormattedDate = (date: Date | undefined) => {
+  if (!date)
+    return {
+      yearMonthDay: '',
+      monthDay: '',
+      dayOfWeek: '',
+      monthDayWithDayOfWeek: '날짜를 선택해주세요',
+    };
+
+  const yearMonthDay = format(date, 'yyyy년 MM월 dd일', { locale: ko });
+  const monthDay = format(date, 'MM월 dd일', { locale: ko });
+  const dayOfWeek = format(date, 'EEEE', { locale: ko });
+  const monthDayWithDayOfWeek = `${monthDay} (${dayOfWeek})`;
+
+  return {
+    yearMonthDay,
+    monthDay,
+    dayOfWeek,
+    monthDayWithDayOfWeek,
+  };
+};
+
+export default useFormattedDate;


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 관련 이슈

closed #111 

## 변경 사항
- dropdown에서 items가 없으면 calendar컴포넌트가 나타납니다 참고 바랍니다
- useFormatedDate 훅을 만들었습니다. 
---
**useFormatedDate 훅 사용방법**
props로 Date를 받음
-  yearMonthDay = 년 월 일 출력, 
- monthDay = 월 일 출력, 
- dayOfWeek = 요일 출력 
- monthDayWithDayOfWeek = 월 일 (요일) 출력
<!-- ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->

## 테스트 방법(선택)

<!-- ex) 어느 브랜치인지 이동 / 어떤 동작을 하는지 테스트하는 방법을 설명해주세요 -->

## 스크린샷(선택)
