### PR TITLE
메인페이지 지역 선택 시 전체도 나오게 하기

### DIFF
--- a/src/components/common/Dropdown/index.tsx
+++ b/src/components/common/Dropdown/index.tsx
@@ -69,7 +69,11 @@ export default function Dropdown({
   const handleItemClick = (e: React.MouseEvent<HTMLDivElement>) => {
     const itemText = e.currentTarget?.textContent;
     if (handleLocationClick) {
-      handleLocationClick(itemText);
+      if (itemText === '전체') {
+        handleLocationClick(null);
+      } else {
+        handleLocationClick(itemText);
+      }
     }
     setIsOpen(false);
     setItemValue(itemText);
@@ -105,7 +109,7 @@ export default function Dropdown({
     <div ref={dropdownRef} className="relative z-10">
       <button
         onClick={toggleDropdown}
-        className={`${isSelectedValue && '!text-black'} relative flex w-full items-center justify-between truncate rounded-sm bg-neutral-50 px-12 py-10 text-body-2M text-neutral-400 hover:text-primary-300 md:text-body-1M`}
+        className={`${isSelectedValue && '!text-black'} ${itemTrigger === '지역선택' && 'w-97'} relative flex w-full items-center justify-between truncate rounded-sm bg-neutral-50 px-12 py-10 text-body-2M text-neutral-400 hover:text-primary-300 md:text-body-1M`}
         type="button"
       >
         {itemValue}
@@ -123,7 +127,15 @@ export default function Dropdown({
       {/* 이후 고정 값 나오면 변경작업 */}
       {isOpen ? (
         items && items.length > 0 ? (
-          <div className="absolute z-10 max-h-176 w-full overflow-y-scroll rounded-md bg-white px-4 py-5 text-body-2Sb shadow-lg scrollbar-none">
+          <div className="absolute z-10 max-h-176 w-full overflow-y-scroll rounded-md bg-white px-4 py-5 text-body-2Sb shadow-lg">
+            {itemTrigger === '지역선택' && (
+              <div
+                className="flex w-full cursor-pointer items-center justify-center px-10 py-12 hover:rounded-full hover:bg-primary-50 active:bg-primary-100"
+                onClick={handleItemClick}
+              >
+                전체
+              </div>
+            )}
             {items.map((item, index) => (
               <div
                 key={index}


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 관련 이슈

closed #196 

## 변경 사항

<!-- ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->
메인페이지에서 지역 선택 시 드롭다운에 전체 선택지도 나오게 구현하였습니다.
- 전체 선택 시 null이 전달되도록 하였습니다.

## 테스트 방법(선택)

<!-- ex) 어느 브랜치인지 이동 / 어떤 동작을 하는지 테스트하는 방법을 설명해주세요 -->

## 스크린샷(선택)
![image](https://github.com/user-attachments/assets/07512fb9-bff1-41c7-8b7c-21101937bed3)
